### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 このリポジトリは、Model Context Protocol (MCP) を使用して天気情報を提供するシンプルなサービスです。複数の都市（福岡、東京、大阪、モスクワ、ニューヨークなど）の天気情報を取得できます。
 
+<a href="https://glama.ai/mcp/servers/@terisuke/my-weather-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@terisuke/my-weather-mcp/badge" alt="Weather Service MCP server" />
+</a>
+
 ## 目次
 
 1. [前提条件](#前提条件)


### PR DESCRIPTION
This PR adds a badge for the [MCP Weather Service](https://glama.ai/mcp/servers/@terisuke/my-weather-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@terisuke/my-weather-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@terisuke/my-weather-mcp/badge" alt="Weather Service MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.